### PR TITLE
Fix link to Python repo with movie_data.csv

### DIFF
--- a/ch08/ch08.ipynb
+++ b/ch08/ch08.ipynb
@@ -473,7 +473,7 @@
     "### Note\n",
     "\n",
     "If you have problems with creating the `movie_data.csv`, you can find a download a zip archive at \n",
-    "https://github.com/rasbt/python-machine-learning-book-pytorch-edition/tree/master/code/ch08/\n",
+    "https://github.com/rasbt/machine-learning-book/tree/main/ch08/\n",
     "\n",
     "---"
    ]
@@ -1396,8 +1396,8 @@
     "              'in this directory. You can obtain it by'\n",
     "              'a) executing the code in the beginning of this'\n",
     "              'notebook or b) by downloading it from GitHub:'\n",
-    "              'https://github.com/rasbt/python-machine-learning-'\n",
-    "              'book-2nd-edition/blob/master/code/ch08/movie_data.csv.gz')\n",
+    "              'https://github.com/rasbt/machine-learning-book/'\n",
+    "              'blob/main/ch08/movie_data.csv.gz')\n",
     "    else:\n",
     "        with gzip.open('movie_data.csv.gz', 'rb') as in_f, \\\n",
     "                open('movie_data.csv', 'wb') as out_f:\n",

--- a/ch08/ch08.py
+++ b/ch08/ch08.py
@@ -198,7 +198,7 @@ df.shape
 # ### Note
 # 
 # If you have problems with creating the `movie_data.csv`, you can find a download a zip archive at 
-# https://github.com/rasbt/python-machine-learning-book-pytorch-edition/tree/master/code/ch08/
+# https://github.com/rasbt/machine-learning-book/tree/main/ch08/
 # 
 # ---
 
@@ -559,8 +559,8 @@ if not os.path.isfile('movie_data.csv'):
               'in this directory. You can obtain it by'
               'a) executing the code in the beginning of this'
               'notebook or b) by downloading it from GitHub:'
-              'https://github.com/rasbt/python-machine-learning-'
-              'book-2nd-edition/blob/master/code/ch08/movie_data.csv.gz')
+              'https://github.com/rasbt/machine-learning-book/'
+              'blob/main/ch08/movie_data.csv.gz')
     else:
         with gzip.open('movie_data.csv.gz', 'rb') as in_f,                 open('movie_data.csv', 'wb') as out_f:
             out_f.write(in_f.read())


### PR DESCRIPTION
The original link points to
https://github.com/rasbt/python-machine-learning-book-pytorch-edition but that
repo does not exist (and does not redirect to another repo that may have been
renamed to). However, this repo has this file, so change the URL to point here.

Updated both IPython notebook and the generated Python file similarly.