### PR TITLE
Fix Python script name and Markdown formatting

### DIFF
--- a/ch01/README.md
+++ b/ch01/README.md
@@ -10,28 +10,28 @@ Python Machine Learning - Code Examples
 
 ## Setting Up Your Python Environment
 
-This chapter does not contain any code examples, but we recommend you to set up and check your Python before your proceed with the next chapters. 
+This chapter does not contain any code examples, but we recommend you to set up and check your Python before your proceed with the next chapters.
 
 For more detailed setup instructions, please refer to the section ***Installing Python and packages from the Python Package Index*** in Chapter 1.
 
 
 ## Checking Your Python Environment
 
-To verify that your Python environment is set up for the following chapters, we recommend running the `[../python-environment-check.py](../python-environment-check.py)` script provided in the main folder of this repository. 
+To verify that your Python environment is set up for the following chapters, we recommend running the [`../python_environment_check.py`](../python_environment_check.py) script provided in the main folder of this repository.
 
-You can run the `python-environment-check.py` via 
+You can run the `python_environment_check.py` script via
 
-    python python-environment-check.py
+    python python_environment_check.py
 
-or 
+or
 
-    python3 python-environment-check.py
+    python3 python_environment_check.py
 
 Shown below is an example output:
 
 ```python
-(base) sebastian@MacBook-Air ~/Desktop/Python-Machine-Learning-PyTorch-Edition/ch01 % python ../python-environment-check.py 
-[OK] Your Python version is 3.9.6 | packaged by conda-forge | (default, Jul 11 2021, 03:35:11) 
+(base) sebastian@MacBook-Air ~/Desktop/Python-Machine-Learning-PyTorch-Edition/ch01 % python ../python_environment_check.py
+[OK] Your Python version is 3.9.6 | packaged by conda-forge | (default, Jul 11 2021, 03:35:11)
 [Clang 11.1.0 ]
 [OK] numpy 1.21.2
 [OK] scipy 1.7.0
@@ -43,7 +43,7 @@ Shown below is an example output:
 
 ## Jupyter Notebooks
 
-Some readers were wondering about the .ipynb of the code files contained in this repository -- these files are Jupyter notebooks (formerly known as IPython notebooks). 
+Some readers were wondering about the .ipynb of the code files contained in this repository -- these files are Jupyter notebooks (formerly known as IPython notebooks).
 
 Compared to regular .py scripts, Jupyter notebooks allow us to have everything in one place:
 


### PR DESCRIPTION
* Python script has underscores, not dashes
* fix Markdown link formatting
* remove trailing whitespace