### PR TITLE
Label `losses_` docstring as being log loss, not mean squared error

### DIFF
--- a/ch03/ch03.ipynb
+++ b/ch03/ch03.ipynb
@@ -652,7 +652,7 @@
     "    b_ : Scalar\n",
     "      Bias unit after fitting.\n",
     "    losses_ : list\n",
-    "      Mean squared error loss function values in each epoch.\n",
+    "       Log loss function values in each epoch.\n",
     "\n",
     "    \"\"\"\n",
     "    def __init__(self, eta=0.01, n_iter=50, random_state=1):\n",

--- a/ch03/ch03.py
+++ b/ch03/ch03.py
@@ -314,7 +314,7 @@ class LogisticRegressionGD:
     b_ : Scalar
       Bias unit after fitting.
     losses_ : list
-      Mean squared error loss function values in each epoch.
+      Log loss function values in each epoch.
 
     """
     def __init__(self, eta=0.01, n_iter=50, random_state=1):


### PR DESCRIPTION
The docstring for `LogisticRegressionGD.losses_` specifies that is it composed of the mean squared error, when I think it's composed of log loss. Changed the docstring to reflect that.

---

Thanks for the book!
