### PR TITLE
Fix .long() issue in script file

### DIFF
--- a/ch12/ch12_part2.py
+++ b/ch12/ch12_part2.py
@@ -285,7 +285,7 @@ for epoch in range(num_epochs):
 
     for x_batch, y_batch in train_dl:
         pred = model(x_batch)
-        loss = loss_fn(pred.long(), y_batch)
+        loss = loss_fn(pred, y_batch.long())
         loss.backward()
         optimizer.step()
         optimizer.zero_grad()


### PR DESCRIPTION
For some reason, the `ch12.py` script file had a 

        loss = loss_fn(pred.long(), y_batch)

instead of

        loss = loss_fn(pred, y_batch.long())

The `ch12.ipynb` file was ok.