### PR TITLE
Updates affinity -> metric in agglomerative clustering for sklearn > 1.2

### DIFF
--- a/ch10/ch10.ipynb
+++ b/ch10/ch10.ipynb
@@ -1287,12 +1287,21 @@
     }
    ],
    "source": [
+    "from packaging import version\n",
     "from sklearn.cluster import AgglomerativeClustering\n",
     "\n",
     "\n",
-    "ac = AgglomerativeClustering(n_clusters=3, \n",
-    "                             affinity='euclidean', \n",
-    "                             linkage='complete')\n",
+    "if version.parse(sklearn.__version__) > version.parse(\"1.2\"):\n",
+    "    ac = AgglomerativeClustering(n_clusters=3,\n",
+    "                                 metric=\"euclidean\",\n",
+    "                                 linkage=\"complete\"\n",
+    "                                )\n",
+    "else:\n",
+    "    ac = AgglomerativeClustering(n_clusters=3,\n",
+    "                                 affinity=\"euclidean\",\n",
+    "                                 linkage=\"complete\"\n",
+    "                                )\n",
+    "\n",
     "labels = ac.fit_predict(X)\n",
     "print(f'Cluster labels: {labels}')"
    ]
@@ -1311,9 +1320,17 @@
     }
    ],
    "source": [
-    "ac = AgglomerativeClustering(n_clusters=2, \n",
-    "                             affinity='euclidean', \n",
-    "                             linkage='complete')\n",
+    "if version.parse(sklearn.__version__) > version.parse(\"1.2\"):\n",
+    "    ac = AgglomerativeClustering(n_clusters=2,\n",
+    "                                 metric=\"euclidean\",\n",
+    "                                 linkage=\"complete\"\n",
+    "                                )\n",
+    "else:\n",
+    "    ac = AgglomerativeClustering(n_clusters=2,\n",
+    "                                 affinity=\"euclidean\",\n",
+    "                                 linkage=\"complete\"\n",
+    "                                )\n",
+    "\n",
     "labels = ac.fit_predict(X)\n",
     "print(f'Cluster labels: {labels}')"
    ]
@@ -1570,7 +1587,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.6"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/ch10/ch10.py
+++ b/ch10/ch10.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-
+from packaging import version
 import sys
 from python_environment_check import check_packages
 from sklearn.datasets import make_blobs
@@ -450,18 +450,34 @@ plt.show()
 
 
 
-ac = AgglomerativeClustering(n_clusters=3, 
-                             affinity='euclidean', 
-                             linkage='complete')
+if version.parse(sklearn.__version__) > version.parse("1.2"):
+    ac = AgglomerativeClustering(n_clusters=3,
+                                 metric="euclidean",
+                                 linkage="complete"
+                                )
+else:
+    ac = AgglomerativeClustering(n_clusters=3,
+                                 affinity="euclidean",
+                                 linkage="complete"
+                                )
+
 labels = ac.fit_predict(X)
 print(f'Cluster labels: {labels}')
 
 
 
 
-ac = AgglomerativeClustering(n_clusters=2, 
-                             affinity='euclidean', 
-                             linkage='complete')
+if version.parse(sklearn.__version__) > version.parse("1.2"):
+    ac = AgglomerativeClustering(n_clusters=2,
+                                 metric="euclidean",
+                                 linkage="complete"
+                                )
+else:
+    ac = AgglomerativeClustering(n_clusters=2,
+                                 affinity="euclidean",
+                                 linkage="complete"
+                                )
+
 labels = ac.fit_predict(X)
 print(f'Cluster labels: {labels}')
 


### PR DESCRIPTION
This PR address an issue where for sklearn > 1.2, affinity was deprecated and renamed to metric.

Fixes #187 