### PR TITLE
error fixed on line 419 ch12_part2.ipynb

### DIFF
--- a/ch12/ch12_part2.ipynb
+++ b/ch12/ch12_part2.ipynb
@@ -416,7 +416,7 @@
     "X_test = np.linspace(0, 9, num=100, dtype='float32').reshape(-1, 1)\n",
     "X_test_norm = (X_test - np.mean(X_train)) / np.std(X_train)\n",
     "X_test_norm = torch.from_numpy(X_test_norm)\n",
-    "y_pred = model(X_test_norm).detach().numpy()\n",
+    "y_pred = model(X_test_norm)\n",
     "\n",
     "\n",
     "fig = plt.figure(figsize=(13, 5))\n",


### PR DESCRIPTION
Hi Sebastian & team,
I was going through the PyTorch notebook and found one error. It was caused by the repetition of the use of `.detach().numpy()`, which needs to be removed from one place. 
Thanks & warm regards
Vanshika

PS. your book is great for basic concepts