### PR TITLE
Fix loss calculation in LogisticRegressionGD

### DIFF
--- a/ch03/ch03.py
+++ b/ch03/ch03.py
@@ -349,7 +349,7 @@ class LogisticRegressionGD:
             errors = (y - output)
             self.w_ += self.eta * X.T.dot(errors) / X.shape[0]
             self.b_ += self.eta * errors.mean()
-            loss = -y.dot(np.log(output)) - ((1 - y).dot(np.log(1 - output))) / X.shape[0]
+            loss = (-y.dot(np.log(output)) - (1 - y).dot(np.log(1 - output))) / X.shape[0]
             self.losses_.append(loss)
         return self
 


### PR DESCRIPTION
The division by `X.shape[0]` should apply to the entire previous term. This matches the code in the Jupyter notebook version of this file