### PR TITLE
Fix typo in kernel parameter for SVC from 'rbg' to 'rbf' (Radial Basis Function)

### DIFF
--- a/ch06/ch06.py
+++ b/ch06/ch06.py
@@ -375,7 +375,7 @@ param_grid = [{'svc__C': param_range,
                'svc__kernel': ['linear']},
               {'svc__C': param_range,
                'svc__gamma': param_range,
-               'svc__kernel': ['rbg']}]
+               'svc__kernel': ['rbf']}]
 
 
 rs = RandomizedSearchCV(estimator=pipe_svc,


### PR DESCRIPTION
the param_grid for the randomizedSearch has a typo, instead of rbf, rbg is written which is incorrect.